### PR TITLE
Fix: Navigation does not become selected in production build

### DIFF
--- a/src/components/react/GlobalNavigation.tsx
+++ b/src/components/react/GlobalNavigation.tsx
@@ -13,7 +13,8 @@ interface Props {
 
 const GlobalNavigation: FC<Props> = ({ currentPath, allComponentPostData }) => {
   const isCurrent = (path: string): boolean => {
-    return currentPath.endsWith(path);
+    // In the production build, trailing "/" is added to the end of the string. Remove "/" to unify formatting.
+    return currentPath.replace(/\/$/, '') === path;
   };
 
   const onClickClose = () => {


### PR DESCRIPTION
# Overview

- Navigation does not become selected in production build
- Only for production builds, there may be a trailing slash in the path
- I reproduced it with `npm run build && npm run preview`
- Remove trailing slash to unify paths

# Video

https://github.com/ubie-oss/ubie-vitals-website/assets/10903851/f799f90c-fd70-46d8-a03e-a9de01df1325


