### PR TITLE
FIX: Temporarily hide icon name and copy function

### DIFF
--- a/src/components/react/IconList/index.tsx
+++ b/src/components/react/IconList/index.tsx
@@ -1,49 +1,55 @@
-import CopyButton from '@components/react/CopyButton';
 import * as icons from '@ubie/ubie-icons';
 import styles from './index.module.css';
 import type { FC } from 'react';
 
 const iconArray = Object.values(icons);
 
-const splitPascalCase = (name: string): string[] => {
-  const result = name.match(/[A-Z][a-z]+|[A-Z]/g);
-  if (result === null) {
-    return [];
-  }
-  return result;
+// TODO:
+// 名前の表示にコンポーネントの名前を使っていたが、ビルド時に消えることがわかった
+// 名前関連の処理は一旦コメントアウト
+// アイコン側に名前情報を持たせる
+
+// const splitPascalCase = (name: string): string[] => {
+//   const result = name.match(/[A-Z][a-z]+|[A-Z]/g);
+//   if (result === null) {
+//     return [];
+//   }
+//   return result;
+// };
+
+// const IconName: FC<{ name: string }> = ({ name }) => {
+//   return splitPascalCase(name).map((word, index) => (
+//     <span className={styles.word} key={`${word}-${index}`}>
+//       {word}
+//     </span>
+//   ));
+// };
+
+// const deletePrefix = (name: string) => name.replace('Svg', '');
+// const deleteSuffix = (name: string) => name.replace('Icon', '');
+
+// const convertToDisplayName = (componentName: string) => {
+//   return deleteSuffix(deletePrefix(componentName));
+// };
+
+// const convertToIconComponentName = (componentName: string) => {
+//   return deletePrefix(componentName);
+// };
+
+const IconList: FC = () => {
+  return (
+    <ul className={styles.list}>
+      {iconArray.map((Icon, index) => (
+        <li className={styles.item} key={index}>
+          <div className={styles.icon} aria-label={`アイコン${index}`}>
+            <Icon key={Icon.name} />
+          </div>
+          {/* <p className={styles.name}>{<IconName name={convertToDisplayName(Icon.name)}></IconName>}</p> */}
+          {/* <CopyButton text={convertToIconComponentName(Icon.name)} className={styles.copy} /> */}
+        </li>
+      ))}
+    </ul>
+  );
 };
-
-const IconName: FC<{ name: string }> = ({ name }) => {
-  return splitPascalCase(name).map((word, index) => (
-    <span className={styles.word} key={`${word}-${index}`}>
-      {word}
-    </span>
-  ));
-};
-
-const deletePrefix = (name: string) => name.replace('Svg', '');
-const deleteSuffix = (name: string) => name.replace('Icon', '');
-
-const convertToDisplayName = (componentName: string) => {
-  return deleteSuffix(deletePrefix(componentName));
-};
-
-const convertToIconComponentName = (componentName: string) => {
-  return deletePrefix(componentName);
-};
-
-const IconList: FC = () => (
-  <ul className={styles.list}>
-    {iconArray.map((Icon, index) => (
-      <li className={styles.item} key={`${Icon.name}-${index}`}>
-        <div className={styles.icon} aria-label={`${Icon.name}のアイコン`}>
-          <Icon key={Icon.name} />
-        </div>
-        <p className={styles.name}>{<IconName name={convertToDisplayName(Icon.name)}></IconName>}</p>
-        <CopyButton text={convertToIconComponentName(Icon.name)} className={styles.copy} />
-      </li>
-    ))}
-  </ul>
-);
 
 export default IconList;

--- a/src/components/react/IconList/index.tsx
+++ b/src/components/react/IconList/index.tsx
@@ -41,7 +41,7 @@ const IconList: FC = () => {
     <ul className={styles.list}>
       {iconArray.map((Icon, index) => (
         <li className={styles.item} key={index}>
-          <div className={styles.icon} aria-label={`アイコン${index}`}>
+          <div className={styles.icon} aria-label={`アイコン${index}`} role="img">
             <Icon key={Icon.name} />
           </div>
           {/* <p className={styles.name}>{<IconName name={convertToDisplayName(Icon.name)}></IconName>}</p> */}


### PR DESCRIPTION
# Overview

ref: https://ubie.atlassian.net/browse/DSGNPB-173

- Icon names are not displayed correctly
- Names are lost from components in production builds
- Icon component needs to have name information
- Temporarily hide the name (and associated copy function)

# Screenshot

<img width="1246" alt="スクリーンショット 2023-09-14 12 12 10" src="https://github.com/ubie-oss/ubie-vitals-website/assets/10903851/1c241077-7692-43fc-8763-3817c3cb776e">
