### PR TITLE
Duplication of narrow leading

### DIFF
--- a/src/components/react/figures/typography/BodyList.tsx
+++ b/src/components/react/figures/typography/BodyList.tsx
@@ -37,7 +37,7 @@ const BodyList: FC = () => {
           <ExampleText
             type="body"
             size="sm"
-            leading="narrow"
+            leading="tight"
             src="/assets/images/figures/typography/example-text-body-sm-tight.svg"
             alt="Body/sm-tightでテキストを表示した場合のサンプル"
             width="352"
@@ -74,7 +74,7 @@ const BodyList: FC = () => {
           <ExampleText
             type="body"
             size="md"
-            leading="narrow"
+            leading="tight"
             src="/assets/images/figures/typography/example-text-body-md-tight.svg"
             alt="Body/md-tightでテキストを表示した場合のサンプル"
             width="352"


### PR DESCRIPTION
- Duplication of narrow leading
- The image was `tight`, but the copied code was `narrow`.