### PR TITLE
`CopyButton`の名前と状態のSR読み上げの改善

### DIFF
--- a/src/components/react/CopyButton.tsx
+++ b/src/components/react/CopyButton.tsx
@@ -25,24 +25,32 @@ const ButtonCopy: FC<Props> = ({ text, className = '', label, invert }) => {
   };
 
   return (
-    <button
-      type="button"
-      className={clsx([styles.button, { [`${styles.invert}`]: invert }, className])}
-      onClick={handleClick}
-      title={label}
-    >
+    <>
+      <button
+        type="button"
+        className={clsx([styles.button, { [`${styles.invert}`]: invert }, className])}
+        onClick={handleClick}
+        title={label}
+        aria-label={label ? `コピー: ${label}` : 'コピー'}
+      >
+        {copied ? (
+          <span className={styles.icon}>
+            <CheckAIcon />
+          </span>
+        ) : label ? (
+          label
+        ) : (
+          <span className={styles.icon}>
+            <CopyIcon />
+          </span>
+        )}
+      </button>
       {copied ? (
-        <span className={styles.icon} aria-label="コピー">
-          <CheckAIcon />
-        </span>
-      ) : label ? (
-        label
-      ) : (
-        <span className={styles.icon} aria-label="コピー完了">
-          <CopyIcon />
-        </span>
-      )}
-    </button>
+        <div className={clsx('visuallyHidden')} role="status">
+          コピー完了
+        </div>
+      ) : null}
+    </>
   );
 };
 


### PR DESCRIPTION
## AS IS
- `button > span`が`role=generic`なのに`aria-label`を持っていた
- 名前が「コピー」「コピー完了」と切り替わるがSRに通知されない
- 「コピー完了」から「コピー」には2000msで自動的にもとに戻る

## TO BE
- `aria-label`を`span`から剥がして`button`に移動
- 名前を「コピー」で固定し、`role=status`要素に「コピー完了」と通知させるように要素追加
- ビジュアルに変更はありません
