### PR TITLE
`GlobalNavigation`のHTML構造改善

### DIFF
--- a/src/components/react/GlobalNavigation.tsx
+++ b/src/components/react/GlobalNavigation.tsx
@@ -40,64 +40,66 @@ const GlobalNavigation: FC<Props> = ({ currentPath, allComponentPostData }) => {
                 Principles
               </GlobalNavigationLinkRoot>
             </li>
-
-            <GlobalNavigationAccordion title="Tokens" titleHref="/tokens" currentPath={currentPath}>
-              <ul>
-                <li>
-                  <GlobalNavigationLink current={isCurrent('/tokens/typography')} href="/tokens/typography">
-                    Typography
-                  </GlobalNavigationLink>
-                </li>
-                <li>
-                  <GlobalNavigationLink current={isCurrent('/tokens/color/semantic')} href="/tokens/color/semantic">
-                    Semantic Color
-                  </GlobalNavigationLink>
-                </li>
-                <li>
-                  <GlobalNavigationLink current={isCurrent('/tokens/color/primitive')} href="/tokens/color/primitive">
-                    Primitive Color
-                  </GlobalNavigationLink>
-                </li>
-                <li>
-                  <GlobalNavigationLink current={isCurrent('/tokens/spacing')} href="/tokens/spacing">
-                    Spacing
-                  </GlobalNavigationLink>
-                </li>
-                <li>
-                  <GlobalNavigationLink current={isCurrent('/tokens/radius')} href="/tokens/radius">
-                    Radius
-                  </GlobalNavigationLink>
-                </li>
-                <li>
-                  <GlobalNavigationLink current={isCurrent('/tokens/for-developers')} href="/tokens/for-developers">
-                    For Developers
-                  </GlobalNavigationLink>
-                </li>
-              </ul>
-            </GlobalNavigationAccordion>
-
-            <GlobalNavigationAccordion title="Layouts" titleHref="/layouts" currentPath={currentPath}>
-              <ul>
-                <li>
-                  <GlobalNavigationLink current={isCurrent('/layouts/form')} href="/layouts/form">
-                    Form
-                  </GlobalNavigationLink>
-                </li>
-              </ul>
-            </GlobalNavigationAccordion>
-
-            <GlobalNavigationAccordion title="Components" titleHref="/components" currentPath={currentPath}>
-              <ul>
-                {allComponentPostData.map((postData) => (
-                  <li key={postData.url}>
-                    <GlobalNavigationLink href={postData.url} current={isCurrent(postData.url)}>
-                      {postData.title}
+            <li>
+              <GlobalNavigationAccordion title="Tokens" titleHref="/tokens" currentPath={currentPath}>
+                <ul>
+                  <li>
+                    <GlobalNavigationLink current={isCurrent('/tokens/typography')} href="/tokens/typography">
+                      Typography
                     </GlobalNavigationLink>
                   </li>
-                ))}
-              </ul>
-            </GlobalNavigationAccordion>
-
+                  <li>
+                    <GlobalNavigationLink current={isCurrent('/tokens/color/semantic')} href="/tokens/color/semantic">
+                      Semantic Color
+                    </GlobalNavigationLink>
+                  </li>
+                  <li>
+                    <GlobalNavigationLink current={isCurrent('/tokens/color/primitive')} href="/tokens/color/primitive">
+                      Primitive Color
+                    </GlobalNavigationLink>
+                  </li>
+                  <li>
+                    <GlobalNavigationLink current={isCurrent('/tokens/spacing')} href="/tokens/spacing">
+                      Spacing
+                    </GlobalNavigationLink>
+                  </li>
+                  <li>
+                    <GlobalNavigationLink current={isCurrent('/tokens/radius')} href="/tokens/radius">
+                      Radius
+                    </GlobalNavigationLink>
+                  </li>
+                  <li>
+                    <GlobalNavigationLink current={isCurrent('/tokens/for-developers')} href="/tokens/for-developers">
+                      For Developers
+                    </GlobalNavigationLink>
+                  </li>
+                </ul>
+              </GlobalNavigationAccordion>
+            </li>
+            <li>
+              <GlobalNavigationAccordion title="Layouts" titleHref="/layouts" currentPath={currentPath}>
+                <ul>
+                  <li>
+                    <GlobalNavigationLink current={isCurrent('/layouts/form')} href="/layouts/form">
+                      Form
+                    </GlobalNavigationLink>
+                  </li>
+                </ul>
+              </GlobalNavigationAccordion>
+            </li>
+            <li>
+              <GlobalNavigationAccordion title="Components" titleHref="/components" currentPath={currentPath}>
+                <ul>
+                  {allComponentPostData.map((postData) => (
+                    <li key={postData.url}>
+                      <GlobalNavigationLink href={postData.url} current={isCurrent(postData.url)}>
+                        {postData.title}
+                      </GlobalNavigationLink>
+                    </li>
+                  ))}
+                </ul>
+              </GlobalNavigationAccordion>
+            </li>
             <li>
               <GlobalNavigationLinkRoot href="/elements/icons" current={isCurrent('/elements/icons')}>
                 Icons

--- a/src/components/react/GlobalNavigationAccordion.module.css
+++ b/src/components/react/GlobalNavigationAccordion.module.css
@@ -5,10 +5,6 @@
     cursor: pointer;
 }
 
-.summary::-webkit-details-marker {
-    display: none;
-}
-
 .toggle {
     position: absolute;
     top: 50%;

--- a/src/components/react/GlobalNavigationAccordion.tsx
+++ b/src/components/react/GlobalNavigationAccordion.tsx
@@ -22,7 +22,7 @@ const GlobalNavigationAccordion: FC<Props> = ({ currentPath, title, titleHref, c
     return currentPath.includes(titleHref);
   });
 
-  // oepnComponentsの状態を反転させる。また、クリックイベントをとめる
+  // openComponentsの状態を反転させる。また、クリックイベントをとめる
   const onClickToggle = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     setOpenDetail(!openDetail);

--- a/src/components/react/GlobalNavigationAccordion.tsx
+++ b/src/components/react/GlobalNavigationAccordion.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useId } from 'react';
 import TriDown from '@icons/icon-tri-down.svg';
 import style from './GlobalNavigationAccordion.module.css';
 import GlobalNavigationLinkRoot from './GlobalNavigationLinkRoot';
@@ -18,6 +18,8 @@ const normalizePath = (path: string): string => {
 };
 
 const GlobalNavigationAccordion: FC<Props> = ({ currentPath, title, titleHref, children }) => {
+  const detailId = useId();
+
   const [openDetail, setOpenDetail] = useState(() => {
     return currentPath.includes(titleHref);
   });
@@ -33,24 +35,35 @@ const GlobalNavigationAccordion: FC<Props> = ({ currentPath, title, titleHref, c
   }, [currentPath, titleHref]);
 
   return (
-    <details open={openDetail}>
-      <summary className={style.summary}>
+    <div>
+      <div className={style.summary}>
         <GlobalNavigationLinkRoot href={titleHref} current={isCurrent}>
           {title}
-          <button className={style.toggle} type="button" onClick={onClickToggle}>
-            <img
-              className={clsx(style.toggleIcon, { [style.open]: openDetail })}
-              src={TriDown.src}
-              width={24}
-              height={24}
-              alt=""
-            />
-          </button>
         </GlobalNavigationLinkRoot>
-      </summary>
-
-      {children}
-    </details>
+        <button
+          className={style.toggle}
+          type="button"
+          onClick={onClickToggle}
+          aria-expanded={openDetail}
+          aria-controls={detailId}
+        >
+          <img
+            className={clsx(style.toggleIcon, { [style.open]: openDetail })}
+            src={TriDown.src}
+            width={24}
+            height={24}
+            alt="サブメニュー"
+          />
+        </button>
+      </div>
+      <div
+        id={detailId}
+        // 本来であれば !openDetail で "until-found" を指定したい
+        hidden={!openDetail}
+      >
+        {children}
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## AS IS

- `GlobalNavigationAccordion`コンポーネントは展開されると`li`要素ではないのに`ul`要素の直下にある
- `summary > a > button`という構造を作っている
  - `summary`はインタラクティブ要素のため、`a`要素を内包する点に問題がある（将来的に`role=button`となるため`role=link`を内包するべきではない）
  - `a`要素の中に`button`要素は仕様で内包できない
- トグルボタン（`button`要素）に名前がない

## TO BE

- `GlobalNavigationAccordion`コンポーネントを`li`要素でラップ
- `details`/`summary`要素の採用を止めて、
  - `a`要素と`button`要素を分離
  - `button`要素は`aria-expanded`と`aria-controls`を付与
  - 展開要素は`hidden`属性を利用
- トグルボタン（`button`要素）の名前に「サブメニュー」を設定
- ビジュアルに変更はありません
- コメント内のタイポの修正を含みます e801ae6de6c47c6068840b3c395db2252f95270e