### PR TITLE
アイコン名のキャメルケース表記を単語間に空白を加えて可読性を改善

### DIFF
--- a/src/components/react/IconList/IconWrapper.module.css
+++ b/src/components/react/IconList/IconWrapper.module.css
@@ -23,6 +23,7 @@
     line-height: var(--text-body-sm-line);
     color: var(--color-text-sub);
     text-align: center;
+    word-wrap: normal;
 }
 
 .copy {
@@ -35,8 +36,4 @@
 .copy:focus,
 .wrapper:hover .copy {
     opacity: 1;
-}
-
-.word {
-    display: inline-block;
 }

--- a/src/components/react/IconList/IconWrapper.tsx
+++ b/src/components/react/IconList/IconWrapper.tsx
@@ -12,27 +12,19 @@ const convertToIconComponentName = (iconName: string) => {
   return `import { ${iconName} } from '@ubie/ubie-icons'`;
 };
 
-const splitUpperCase = (str: string) => {
-  return str.split(/(?=[A-Z])/);
-};
-
 const IconWrapper: FC<Props> = ({ children, index }) => {
   const name = iconNames[index];
 
   if (!name) return null;
 
+  const humanReadableName = name.split(/(?=[A-Z])/).join(' ');
+
   return (
     <div className={styles.wrapper}>
-      <div className={styles.icon} aria-label={`アイコン ${name}`} role="img">
+      <div className={styles.icon} aria-label={`アイコン ${humanReadableName}`} role="img">
         {children}
       </div>
-      <p className={styles.name}>
-        {splitUpperCase(name).map((str, index) => (
-          <span className={styles.word} key={index}>
-            {str}
-          </span>
-        ))}
-      </p>
+      <p className={styles.name}>{humanReadableName}</p>
       <CopyButton label="React" text={convertToIconComponentName(name)} className={styles.copy} />
     </div>
   );


### PR DESCRIPTION
対象: https://vitals.ubie.life/elements/icons/

## AS IS
- アイコン画像の名前・可視ラベル共にアイコン名がキャメルケース
- 可視ラベルのキャメルケースは単語ごとに`span`でマークアップ

## TO BE
- アイコン画像の名前・可視ラベル共に可読性を上げるために単語間に空白を追加
- `span`のマークアップをやめて、CSSで`word-wrap`処理を調整
- ビジュアルの変更は**空白の追加**です