### PR TITLE
`details`/`summary`を利用して停止できないGIFアニメを非表示可能に改善

### DIFF
--- a/src/pages/tokens/for-developers.mdx
+++ b/src/pages/tokens/for-developers.mdx
@@ -14,8 +14,14 @@ Tokensの自動補完をしてくれるVS Codeの機能拡張です。マーケ�
 
 また、CSSカスタムプロパティをホバーすると、その値の詳細が表示さるようになります。
 
-![動画: 途中までカスタムプロパティを入力することで候補が表示される流れ](/assets/images/vscode-plugin-screenshot-autocomplete.gif)
+<details open>
+  <summary>途中までカスタムプロパティを入力することで候補が表示される流れ</summary>
+  ![動画: 途中までカスタムプロパティを入力することで候補が表示される流れ](/assets/images/vscode-plugin-screenshot-autocomplete.gif)
+</details>
 
-![動画; カスタムプロパティをホバーし、詳細な値が表示されている](/assets/images/vscode-plugin-screenshot-hover.gif)
+<details open>
+  <summary>カスタムプロパティをホバーし、詳細な値が表示されている</summary>
+  ![動画: カスタムプロパティをホバーし、詳細な値が表示されている](/assets/images/vscode-plugin-screenshot-hover.gif)
+</details>
 
 ソースコード: [ubie-oss/design-tokens-for-vscode: VS Code extension for building with the Ubie Design System.](https://github.com/ubie-oss/design-tokens-for-vscode)


### PR DESCRIPTION
対象: https://vitals.ubie.life/tokens/for-developers/

## AS IS
- GIFアニメーションが停止できない（[WCAG 2.2 SC 2.2.2 一時停止、停止、非表示](https://waic.jp/translations/WCAG22/#pause-stop-hide)不適合）

## TO BE
- `details[open]`でラップすることで、非表示可能にした
- `summary`には代替テキストの一部を暫定的に適用
- ビジュアルの変更は **`summary`要素が展開**された点です