### PR TITLE
スクロール可能要素を全ブラウザでフォーカス可能にするために`tabindex`属性を付与

### DIFF
--- a/src/pages/tokens/typography.mdx
+++ b/src/pages/tokens/typography.mdx
@@ -20,7 +20,7 @@ Webを構成する基礎的な要素はテキストです。タイポグラフ�
 
 次のスケールを用います。ただし、このスケールから直接サイズを選ぶことはありません。後述のセマンティックな定義を使用します。
 
-<div class="scrollable">
+<div class="scrollable" tabIndex={0}>
   <img
     src="/assets/images/figures/typography/font-size-scale.svg"
     width="816"


### PR DESCRIPTION
対象: https://vitals.ubie.life/tokens/typography/

## AS IS

- スクロール可能要素が一部のブラウザ（Chromeなど）でフォーカスが当たらないのでキーボードで操作できない

## TO BE

- `tabindex`属性を付与することで、フォーカス可能に改善