### PR TITLE
リンクの目的の改善

### DIFF
--- a/src/components/astro/LinkCard.astro
+++ b/src/components/astro/LinkCard.astro
@@ -6,9 +6,10 @@ interface Props {
   href: string;
   heading: string;
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  id?: string;
 }
 
-const { href, heading, as: HeadingElement = 'h2' } = Astro.props;
+const { href, heading, as: HeadingElement = 'h2', id } = Astro.props;
 ---
 
 <section class="linkCard">
@@ -16,11 +17,11 @@ const { href, heading, as: HeadingElement = 'h2' } = Astro.props;
     <div class="linkCardImageWrapper">
       <slot name="image" />
     </div>
-    <HeadingElement class="heading">{heading}</HeadingElement>
+    <HeadingElement class="heading" id={id}>{heading}</HeadingElement>
     <slot />
   </Stack>
 
-  <LinkWithArrow expandClickableArea href={href}>Explore</LinkWithArrow>
+  <LinkWithArrow expandClickableArea href={href} ariaDescribedBy={id}>Explore</LinkWithArrow>
 </section>
 
 <style>

--- a/src/components/astro/LinkWithArrow.astro
+++ b/src/components/astro/LinkWithArrow.astro
@@ -4,12 +4,13 @@ import { Icon } from 'astro-icon/components';
 interface Props {
   href: string;
   expandClickableArea?: boolean;
+  ariaDescribedBy?: string;
 }
 
-const { href, expandClickableArea = false } = Astro.props;
+const { href, expandClickableArea = false, ariaDescribedBy } = Astro.props;
 ---
 
-<a class:list={['link', { expandClickableArea }]} href={href}>
+<a class:list={['link', { expandClickableArea }]} href={href} aria-describedby={ariaDescribedBy}>
   <slot />
   <Icon class="icon" name="icon-arrow-right" alt="" width="22" height="22" />
 </a>

--- a/src/components/astro/top/CardPrinciples.astro
+++ b/src/components/astro/top/CardPrinciples.astro
@@ -3,18 +3,24 @@ import Stack from '@components/astro/Stack.astro';
 import LinkWithArrow from '@components/astro/LinkWithArrow.astro';
 import { Image } from 'astro:assets';
 import FigurePrinciples from '@assets/images/top/figure-principles.svg';
+
+interface Props {
+  id?: string;
+}
+
+const { id } = Astro.props;
 ---
 
 <div class="wrapper">
   <div class="card primary">
     <Stack spacing="lg">
-      <h2 class="cardHeading primary">Design Principles</h2>
+      <h2 class="cardHeading primary" id={id}>Design Principles</h2>
       <p>
         デザイン上において目指すべき指針を言語化したものがDesign Principles（デザイン原則）です。<b
           >誰でも、効率よく、迷わずに</b
         >、Ubieらしい表現をするための基礎です。
       </p>
-      <LinkWithArrow href="/principles" expandClickableArea>Learn More</LinkWithArrow>
+      <LinkWithArrow href="/principles" expandClickableArea ariaDescribedBy={id}>Learn More</LinkWithArrow>
     </Stack>
 
     <div class="imgWrapper">

--- a/src/pages/components/index.astro
+++ b/src/pages/components/index.astro
@@ -13,6 +13,7 @@ const allComponentPostData: PostData[] = allComponentMdx.map((componentMdx) => {
     description: componentMdx.frontmatter.description ? componentMdx.frontmatter.description : '',
     url: componentMdx.url ? componentMdx.url : '',
     thumbnail: componentMdx.frontmatter.thumbnail,
+    id: componentMdx.url?.split('/').at(-1),
   };
 });
 ---
@@ -32,12 +33,14 @@ const allComponentPostData: PostData[] = allComponentMdx.map((componentMdx) => {
                 <Image class="itemThumbnail" src={postData.thumbnail} alt={postData.title} width={560} height={315} />
               )}
               <Stack spacing="sm">
-                <p class="itemTitle">{postData.title}</p>
+                <p class="itemTitle" id={postData.id}>
+                  {postData.title}
+                </p>
                 <p class="itemDesccription">{postData.description}</p>
               </Stack>
 
               <div class="link">
-                <LinkWithArrow expandClickableArea href={postData.url}>
+                <LinkWithArrow expandClickableArea href={postData.url} ariaDescribedBy={postData.id}>
                   Learn More
                 </LinkWithArrow>
               </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,27 +18,27 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 
     <div class="wrapper">
       <Stack spacing="xl">
-        <CardPrinciples />
+        <CardPrinciples id="design-principles" />
 
         <div class="cardList">
-          <LinkCard href="/tokens" heading="Tokens">
+          <LinkCard href="/tokens" heading="Tokens" id="tokens">
             <Image src={FigureTokens} alt="" slot="image" />
             <p>
               タイポグラフィ、カラー、スペーシングなど、デザインの最小単位。ユビー「らしさ」を確保するための基本ルールです。
             </p>
           </LinkCard>
 
-          <LinkCard href="/components" heading="Components">
+          <LinkCard href="/components" heading="Components" id="components">
             <Image src={FigureComponents} alt="" slot="image" />
             <p>組み合わせによる、迅速なプロダクト構築をサポートします。コードサンプルと使用方法を紹介します。</p>
           </LinkCard>
 
-          <LinkCard href="/layouts" heading="Layouts">
+          <LinkCard href="/layouts" heading="Layouts" id="layouts">
             <Image src={FigureLayouts} alt="" slot="image" />
             <p>複数のコンポーネントを組み合わせて、複雑なレイアウトを構築する実例を紹介します。</p>
           </LinkCard>
 
-          <LinkCard href="/elements/icons" heading="Icons">
+          <LinkCard href="/elements/icons" heading="Icons" id="icons">
             <Image src={FigureIcons} alt="" slot="image" />
             <p>視覚的にユーザーの視認性をサポートするアイコンの一覧です。</p>
           </LinkCard>

--- a/src/pages/layouts/index.astro
+++ b/src/pages/layouts/index.astro
@@ -13,6 +13,7 @@ const allComponentPostData: PostData[] = allComponentMdx.map((componentMdx) => {
     description: componentMdx.frontmatter.description ? componentMdx.frontmatter.description : '',
     url: componentMdx.url ? componentMdx.url : '',
     thumbnail: componentMdx.frontmatter.thumbnail,
+    id: componentMdx.url?.split('/').at(-1),
   };
 });
 ---
@@ -32,12 +33,14 @@ const allComponentPostData: PostData[] = allComponentMdx.map((componentMdx) => {
                 <Image class="itemThumbnail" src={postData.thumbnail} alt={postData.title} width={560} height={315} />
               )}
               <Stack spacing="sm">
-                <p class="itemTitle">{postData.title}</p>
+                <p class="itemTitle" id={postData.id}>
+                  {postData.title}
+                </p>
                 <p class="itemDesccription">{postData.description}</p>
               </Stack>
 
               <div class="link">
-                <LinkWithArrow expandClickableArea href={postData.url}>
+                <LinkWithArrow expandClickableArea href={postData.url} ariaDescribedBy={postData.id}>
                   Learn More
                 </LinkWithArrow>
               </div>

--- a/src/pages/tokens/index.astro
+++ b/src/pages/tokens/index.astro
@@ -11,6 +11,7 @@ const allComponentPostData: PostData[] = allComponentMdx.map((componentMdx) => {
     title: componentMdx.frontmatter.title ? componentMdx.frontmatter.title : '',
     description: componentMdx.frontmatter.description ? componentMdx.frontmatter.description : '',
     url: componentMdx.url ? componentMdx.url : '',
+    id: componentMdx.url?.split('/').at(-1),
   };
 });
 ---
@@ -29,10 +30,12 @@ const allComponentPostData: PostData[] = allComponentMdx.map((componentMdx) => {
           allComponentPostData.map((postData) => (
             <li class="item">
               <Stack spacing="sm">
-                <p class="itemTitle">{postData.title}</p>
+                <p class="itemTitle" id={postData.id}>
+                  {postData.title}
+                </p>
                 <p class="itemDesccription">{postData.description}</p>
               </Stack>
-              <LinkWithArrow expandClickableArea href={postData.url}>
+              <LinkWithArrow expandClickableArea href={postData.url} ariaDescribedBy={postData.id}>
                 Learn More
               </LinkWithArrow>
             </li>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export type PostData = {
   description: string;
   url: string;
   thumbnail?: string;
+  id?: string;
 };
 
 export type Spacing = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';


### PR DESCRIPTION
## 対象
- https://vitals.ubie.life/
- https://vitals.ubie.life/tokens/
- https://vitals.ubie.life/layouts/
- https://vitals.ubie.life/components/

## AS IS

- リンク「Learn more」「Expore」が目的を的確に表現できていない（[WCAG 2.2 SC 2.4.4 リンクの目的 (コンテキスト内)](https://waic.jp/translations/WCAG22/#link-purpose-in-context)不適合）

## TO BE

- 応急対応として近い見出し要素と`aria-describedby`で関連付けを行い補足