### PR TITLE
カラーコントラストのサンプルテキストを`role=img`として代替テキストを付与

### DIFF
--- a/src/components/react/figures/color/ColorChip.tsx
+++ b/src/components/react/figures/color/ColorChip.tsx
@@ -31,10 +31,16 @@ const ColorChip: FC<Props> = ({ token }) => {
     <div className={styles.outline} aria-describedby={`${token.name}-heading`}>
       <div className={styles.tile} style={{ backgroundColor: token.value }}>
         <p className={styles.textBlack}>
-          A <ColorChipValidationIndicator valid={blackIsValid.AA.normal}></ColorChipValidationIndicator>
+          <span role="img" aria-label="文字色: 黒">
+            A
+          </span>{' '}
+          <ColorChipValidationIndicator valid={blackIsValid.AA.normal}></ColorChipValidationIndicator>
         </p>
         <p className={styles.textWhite}>
-          A <ColorChipValidationIndicator valid={whiteIsValid.AA.normal}></ColorChipValidationIndicator>
+          <span role="img" aria-label="文字色: 白">
+            A
+          </span>{' '}
+          <ColorChipValidationIndicator valid={whiteIsValid.AA.normal}></ColorChipValidationIndicator>
         </p>
       </div>
 


### PR DESCRIPTION
対象: https://vitals.ubie.life/tokens/color/primitive/

## AS IS
- 黒文字・白文字のテキスト「A」がCSSで色がついているが名前などからはそれが黒なのか白なのか判別できない

## TO BE
- テキスト「A」を`role=img`でマークアップし、`aria-label`を使い代替テキストを設定した