### PR TITLE
remove accent variant

### DIFF
--- a/src/pages/getting-started/index.mdx
+++ b/src/pages/getting-started/index.mdx
@@ -60,7 +60,6 @@ const Default: FC = () => {
     <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px', flexWrap: 'wrap' }}>
       <Button>ボタン</Button>
       <Button variant="secondary">ボタン</Button>
-      <Button variant="accent">ボタン</Button>
       <Button variant="alert">ボタン</Button>
       <Button variant="text">ボタン</Button>
       <Button variant="textAlert">ボタン</Button>


### PR DESCRIPTION
とてもNITSです

`accent`はもう存在しない variant のようでしたので、ドキュメントから削除しました。